### PR TITLE
Travis: Use 'Trusty' compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
+dist: trusty
 language: java
 jdk:
   - oraclejdk8
-
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer
 
 script: ant build


### PR DESCRIPTION
Removes the need to update Java before each compilation. Trusty images use more up-to-date software