### PR TITLE
NewGameWindow: Fix game hours always equalling 0

### DIFF
--- a/src/virtualgameshelf/gui/NewGameWindow.java
+++ b/src/virtualgameshelf/gui/NewGameWindow.java
@@ -158,7 +158,7 @@ public class NewGameWindow extends Stage {
                     newGame.setCompletion(completionChooser.getValue());
                 }
 
-                if (hoursField.getText() != null || hoursField.getText().trim().isEmpty())
+                if (hoursField.getText() == null || hoursField.getText().trim().isEmpty())
                     newGame.setHours(0);
                 else
                     newGame.setHours(Integer.parseInt(hoursField.getText()));


### PR DESCRIPTION
Fix small typo that made hours always equal to 0