### PR TITLE
GameShelf: Remove workaround for Windows 10 touchscreen PCs

### DIFF
--- a/src/virtualgameshelf/gui/VirtualGameShelf.java
+++ b/src/virtualgameshelf/gui/VirtualGameShelf.java
@@ -33,9 +33,6 @@ public class VirtualGameShelf extends Application {
     private static VBox gameListVBox;
 
     public static void main(String[] args) {
-        // Bugfix: Prevents JavaFX ComboBox freezing on Windows 10
-        // touchscreen computers (http://stackoverflow.com/a/32597281)
-        System.setProperty("glass.accessible.force", "false");
         launch(args);
     }
 


### PR DESCRIPTION
Old JDK versions had a freezing issue when clicking a JavaFX ComboBox on a Windows 10 touchscreen computer. This should be resolved as of JDK 8u72.
Refer to http://stackoverflow.com/a/43266269/3357935 for more information.