### PR TITLE
.travis.yml: Use default build target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ language: java
 jdk:
   - oraclejdk8
 
-script: ant build
+script: ant


### PR DESCRIPTION
Build with default settings from `build.ant`
Changes build target to `makejar`. Previous target was `build`.