### PR TITLE
Release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project (mostly) adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [0.1.0] - 2017-04-13
 ### Added
 * #61 Debug menu for printing gameList and FileIO
 * #62/#79 Game list displayed on program home screen
@@ -37,4 +37,4 @@ Little to no actual functionality.
 * #39/#42: Sort project into packages
 * #50: Separate MenuBar into its own file
 
-[Unreleased]: https://github.com/Stevoisiak/Virtual-Game-Shelf/compare/v0.0.1...HEAD
+[0.1.0]: https://github.com/Stevoisiak/Virtual-Game-Shelf/compare/v0.0.1...v0.1.0


### PR DESCRIPTION
### Added
* #61 Debug menu for printing gameList and FileIO
* #62/#79 Game list displayed on program home screen
* #65 Dropdown list of systems loaded from `system_list.csv`
* #73 'New' menu button clears game
* #83/#88 Save and load gamelist from file

### Changed
* #67 Drop BlueJ support in favor of Eclipse
* #99 System selection changed from dropdown to an auto-completing textbox

### Fixed
* #57 Game hours no longer always equals 0
* #75 Gamelist sorted alphabetically