### PR TITLE
SteamImporter: Use Steam as system when importing game library

### DIFF
--- a/src/virtualgameshelf/backend/persistance/SteamCommunityGameImporter.java
+++ b/src/virtualgameshelf/backend/persistance/SteamCommunityGameImporter.java
@@ -108,7 +108,7 @@ public class SteamCommunityGameImporter {
                     if (!(name.equals(""))) {
                         Game game = new Game();
                         game.setName(name);
-                        game.setSystem("PC");
+                        game.setSystem("Steam");
                         game.setHours(hours);
                         game.setCompletion(completion);
                         game.setRating(0);


### PR DESCRIPTION
I had set it up to use PC as the system, changing that now to correctly use Steam as system instead